### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "datastream",
     "name_pretty": "Datastream",
     "product_documentation": "https://cloud.google.com/datastream/",
-    "client_documentation": "https://googleapis.dev/python/datastream/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/datastream/latest",
     "issue_tracker": "",
     "release_level": "alpha",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.