### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "datastream",
     "name_pretty": "Datastream",
     "product_documentation": "https://cloud.google.com/datastream/",
-    "client_documentation": "https://googleapis.dev/python/datastream/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/datastream/latest",
     "issue_tracker": "",
     "release_level": "alpha",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Client for Datastream
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-datastream.svg
    :target: https://pypi.org/project/google-cloud-datastream/
 .. _Datastream: https://cloud.google.com/datastream
-.. _Client Library Documentation: https://googleapis.dev/python/datastream/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/datastream/latest
 .. _Product Documentation:  https://cloud.google.com/datastream
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.